### PR TITLE
Fix thread safety issue with javax.crypto

### DIFF
--- a/azure-storage/src/main/java/com/microsoft/azure/storage/blob/SharedKeyCredentials.java
+++ b/azure-storage/src/main/java/com/microsoft/azure/storage/blob/SharedKeyCredentials.java
@@ -273,10 +273,11 @@ public final class SharedKeyCredentials implements ICredentials {
      */
     String computeHmac256(final String stringToSign) throws InvalidKeyException {
         try {
+            Mac localMac = (Mac) this.hmacSha256.clone();
             byte[] utf8Bytes = stringToSign.getBytes(Constants.UTF8_CHARSET);
-            return DatatypeConverter.printBase64Binary(this.hmacSha256.doFinal(utf8Bytes));
+            return DatatypeConverter.printBase64Binary(localMac.doFinal(utf8Bytes));
         }
-        catch (final UnsupportedEncodingException e) {
+        catch (final UnsupportedEncodingException | CloneNotSupportedException e) {
             throw new Error(e);
         }
     }


### PR DESCRIPTION
I was getting MAC signature corruption when testing with a high amount of parallelism. I poked around a bit and found this:
https://stackoverflow.com/questions/31898802/is-macdofinal-thread-safe-in-java
Looks like we need to clone the Mac each time we sign so that we don't have different threads modifying the Mac's internal state concurrently.